### PR TITLE
Update java jdk

### DIFF
--- a/appengine/java_appengine.bzl
+++ b/appengine/java_appengine.bzl
@@ -237,7 +237,9 @@ appengine_war_base = rule(
     _war_impl,
     attrs = {
         "_java": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+            # default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+            # default = Label("@rules_java//toolchains:remote_jdk11"),
+            default = Label("@bazel_tools//tools/jdk:remote_jdk11"),
         ),
         "_zipper": attr.label(
             default = Label("@bazel_tools//tools/zip:zipper"),


### PR DESCRIPTION
- Support latest bazel version
- Update appengine version
- support 2.20
- add logging properties
- Update java jdk
